### PR TITLE
Add store command

### DIFF
--- a/pkg/commands/leader.go
+++ b/pkg/commands/leader.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/jakekgrog/ghostdb-cli/pkg/structures"
@@ -16,7 +17,8 @@ var LeaderCmd = &cobra.Command {
 		if addr == "" {
 			fmt.Println("You must supply a value for:\n - The address of a known node in the cluster (e.g. 127.0.0.1:7991)")
 		} else {
-			getLeader(addr)
+			ldr := getLeader(addr)
+			fmt.Println(ldr)
 		}
 	},
 }
@@ -26,8 +28,10 @@ func init() {
 	LeaderCmd.Flags().StringP("addr", "a", "", "specify the address of a known node in a cluster (e.g 127.0.0.1:7991)")
 }
 
-func getLeader(addr string) {
+func getLeader(addr string) string {
 	data := structures.NewEmptyRequest()
 	response := makePostRequest(addr+"/getLeader", data)
-	fmt.Println(response.Message)
+	ldrAddrPort := response.Message
+	ldrAddr := strings.Split(ldrAddrPort, ":")[0]
+	return ldrAddr+":"+defaultPort
 }

--- a/pkg/commands/root.go
+++ b/pkg/commands/root.go
@@ -13,6 +13,10 @@ import (
 	"github.com/jakekgrog/ghostdb-cli/pkg/structures"
 )
 
+var (
+	defaultPort = "7991"
+)
+
 var RootCmd = &cobra.Command {
 	Use:   "GhostDB",
 	Short: "GhostDB Command-line Interface",

--- a/pkg/commands/store.go
+++ b/pkg/commands/store.go
@@ -1,0 +1,58 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/jakekgrog/ghostdb-cli/pkg/structures"
+)
+
+var StoreCmd = &cobra.Command {
+	Use: "store [put|add]",
+	Short: "Put a value in the store",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			cmd.Help()
+			os.Exit(0)
+		}
+
+		key, _   := cmd.Flags().GetString("key")
+		value, _ := cmd.Flags().GetString("value")
+		addr, _  := cmd.Flags().GetString("addr")
+		ldr, _   := cmd.Flags().GetBool("leader")
+		
+		if key == "" || value == "" || addr == ""{
+			fmt.Println("You must supply a value for:")
+			fmt.Println(" - A string value for the key of item you are storing (e.g --key \"myKey\")")
+			fmt.Println(" - The value you want to store (e.g --value \"myValue\")")
+			fmt.Println(" - The address of a node in the cluster (e.g --addr 127.0.0.1:7991)")
+			fmt.Println("   - If --leader flag is not supplied, it must be the clusters leader address")
+		} else {
+			storeValue(args[0], key, value, addr, ldr)
+		}
+	},
+}
+
+func init() {
+	RootCmd.AddCommand(PutCmd)
+	PutCmd.Flags().StringP("key", "k", "", "specify the key for the item")
+	PutCmd.Flags().StringP("value", "v", "", "specify the value for the item")
+	PutCmd.Flags().StringP("addr", "a", "", "specify the address of a node in the cluster (e.g 127.0.0.1:7991)")
+	PutCmd.Flags().BoolP("leader", "l", false, "Allows user to specify the addr of any node and a background call will be made to find the leader")
+}
+
+func storeValue(cmd, key, value, addr string, ldr bool) {
+	if !ldr {
+		// Write to the node at addr.
+		data := structures.NewStoreRequest(key, value)
+		response := makePostRequest(addr+"/"+cmd, data)
+		fmt.Println(response.Message)
+	} else {
+		// get the leader first, then put the value to that node
+		ldrAddr := getLeader(addr)
+		data := structures.NewStoreRequest(key, value)
+		response := makePostRequest(ldrAddr+"/"+cmd, data)
+		fmt.Println(response.Message)
+	}
+}

--- a/pkg/structures/cacheobject.go
+++ b/pkg/structures/cacheobject.go
@@ -13,3 +13,11 @@ func NewEmptyCacheObject() CacheObject {
 		TTL: -1,
 	}
 }
+
+func NewKVCacheObject(key, value string) CacheObject {
+	return CacheObject {
+		Key: key,
+		Value: value,
+		TTL: -1,
+	}
+}

--- a/pkg/structures/request.go
+++ b/pkg/structures/request.go
@@ -9,3 +9,9 @@ func NewEmptyRequest() CacheRequest {
 		Gobj: NewEmptyCacheObject(),
 	}
 }
+
+func NewStoreRequest(key, value string) CacheRequest {
+	return CacheRequest{
+		Gobj: NewKVCacheObject(key, value),
+	}
+}


### PR DESCRIPTION
Added command to store data

Usage:
`store [add|put] -k <string:key> -v <string:value> -a <string:node_address> [-l]`

If the `-l` flag is used, the node address does not need to be the cluster leader. It will attempt to find the leader and commit to it through the node address supplied.